### PR TITLE
Bug Fix: Fix flaky test for org.apache.pinot.core.util.CrcUtilsTest.test1.

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -23,8 +23,8 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -175,7 +175,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
 
     // Initialize index creation
     _segmentIndexCreationInfo = new SegmentIndexCreationInfo();
-    _indexCreationInfoMap = new HashMap<>();
+    _indexCreationInfoMap = new LinkedHashMap<>(); //flaky
 
     // Check if has star tree
     _indexCreator = new SegmentColumnarIndexCreator();
@@ -398,7 +398,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     Set<String> varLengthDictionaryColumns = new HashSet<>(_config.getVarLengthDictionaryColumns());
     Set<String> rawIndexCreationColumns = _config.getRawIndexCreationColumns();
     Set<String> rawIndexCompressionTypeKeys = _config.getRawIndexCompressionType().keySet();
-    for (FieldSpec fieldSpec : _dataSchema.getAllFieldSpecs()) {
+    for (FieldSpec fieldSpec : _dataSchema.getAllFieldSpecs()) { // flaky
       // Ignore virtual columns
       if (fieldSpec.isVirtualColumn()) {
         continue;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -30,7 +30,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +73,7 @@ public final class Schema implements Serializable {
   private List<String> _primaryKeyColumns;
 
   // Json ignored fields
-  private final Map<String, FieldSpec> _fieldSpecMap = new HashMap<>();
+  private final Map<String, FieldSpec> _fieldSpecMap = new LinkedHashMap<>();
   private transient final List<String> _dimensionNames = new ArrayList<>();
   private transient final List<String> _metricNames = new ArrayList<>();
   private transient final List<String> _dateTimeNames = new ArrayList<>();


### PR DESCRIPTION
In the current implementation, when CrcUtils.computeCrc or CrcUtils.computeMD5 is executed, it will encode files in the segment directory, including metadata.properties, which contain the properties in a sequence. However, the order of the properties is not deterministic in the process of producing the segment files due to the non-determinism of HashMap. Instead we should use LinkedHashMap or TreeMap to ensure the determinism. The non-deterministic order of properties may lead to failure of crc verification.